### PR TITLE
Fix detail messages of responses

### DIFF
--- a/src/main/java/com/example/planit/controller/UserController.java
+++ b/src/main/java/com/example/planit/controller/UserController.java
@@ -99,18 +99,22 @@ public class UserController {
 
         } catch (UnauthorizedUserException e) {
             // the user has become unauthorized (not found in the DB)
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(new DTOloginResponseToClient(false, Constants.ERROR_UNAUTHORIZED_USER, e.getSubjectID(), false));
+            logger.error(buildExceptionMessage(e));
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new DTOloginResponseToClient(false, Constants.ERROR_USER_NOT_FOUND, e.getSubjectID(), false));
         } catch (IOException e) {
             // return http response "the auth code is not valid",
+            logger.error(buildExceptionMessage(e));
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(new DTOloginResponseToClient(false, Constants.ERROR_FROM_GOOGLE_API_EXECUTE, null, false));
         } catch (IllegalArgumentException e) {
             // when the authCode is not in the right format
+            logger.error(buildExceptionMessage(e));
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(new DTOloginResponseToClient(false, Constants.ERROR_ILLEGAL_CHARACTERS_IN_AUTH_CODE, null, false));
         } catch (Exception e) {
             // an unknown error had happened
+            logger.error(buildExceptionMessage(e));
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(new DTOloginResponseToClient(false, Constants.ERROR_DEFAULT, null, false));
         }
@@ -143,8 +147,8 @@ public class UserController {
                         .body(new DTOuserClientRepresentation(true, Constants.NO_PROBLEM,
                                 buildUserClientRepresentationFromUser(maybeUser.get())));
             } else {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(new DTOuserClientRepresentation(false, Constants.ERROR_UNAUTHORIZED_USER));
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body(new DTOuserClientRepresentation(false, Constants.ERROR_USER_NOT_FOUND));
             }
         } catch (Exception e) {
             logger.error(buildExceptionMessage(e));
@@ -187,8 +191,8 @@ public class UserController {
                 long res = t - s;
                 logger.info(MessageFormat.format("User {0}: could not save preferences in DB. profile time is {1} ms", sub, res));
 
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(new DTOstatus(false, Constants.ERROR_UNAUTHORIZED_USER));
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body(new DTOstatus(false, Constants.ERROR_USER_NOT_FOUND));
             }
 
         } catch (Exception e) {

--- a/src/main/java/com/example/planit/engine/AdminEngine.java
+++ b/src/main/java/com/example/planit/engine/AdminEngine.java
@@ -89,13 +89,13 @@ public class AdminEngine {
             // Check if course already exists in database by id
             Optional<Course> existingCourseById = courseRepo.findCourseById(course.getCourseId());
             if (existingCourseById.isPresent()) {
-                return new DTOcoursesResponseToController(false, Constants.COURSE_ALREADY_EXIST, HttpStatus.BAD_REQUEST);
+                return new DTOcoursesResponseToController(false, Constants.ERROR_COURSE_ALREADY_EXIST, HttpStatus.BAD_REQUEST);
             }
 
             // Check if course already exists in database by name
             Optional<Course> existingCourseByName = courseRepo.findCourseByCourseName(course.getCourseName());
             if (existingCourseByName.isPresent()) {
-                return new DTOcoursesResponseToController(false, Constants.COURSE_ALREADY_EXIST, HttpStatus.BAD_REQUEST);
+                return new DTOcoursesResponseToController(false, Constants.ERROR_COURSE_ALREADY_EXIST, HttpStatus.BAD_REQUEST);
             }
 
             // Save the new course to the database

--- a/src/main/java/com/example/planit/engine/CalendarEngine.java
+++ b/src/main/java/com/example/planit/engine/CalendarEngine.java
@@ -318,7 +318,7 @@ public class CalendarEngine {
         }
 
         if (!isMtaCalenderFound) {
-            throw new UserCalendarNotFoundException(Constants.COLLEGE_CALENDAR_NOT_FOUND);
+            throw new UserCalendarNotFoundException(Constants.ERROR_COLLEGE_CALENDAR_NOT_FOUND);
         }
 
         // sorts the events, so they will be ordered by start time
@@ -1071,7 +1071,7 @@ public class CalendarEngine {
             // check if user exist in DB
             Optional<User> maybeUser = userRepo.findUserBySubjectID(subjectID);
             if (maybeUser.isEmpty()) {
-                return new DTOscanResponseToController(false, Constants.ERROR_USER_NOT_FOUND, HttpStatus.UNAUTHORIZED);
+                return new DTOscanResponseToController(false, Constants.ERROR_USER_NOT_FOUND, HttpStatus.BAD_REQUEST);
             }
 
             // get instance of the user
@@ -1173,7 +1173,7 @@ public class CalendarEngine {
             // check if user exist in DB
             Optional<User> maybeUser = userRepo.findUserBySubjectID(sub);
             if (maybeUser.isEmpty()) {
-                return new DTOgenerateResponseToController(false, ERROR_USER_NOT_FOUND, HttpStatus.UNAUTHORIZED);
+                return new DTOgenerateResponseToController(false, ERROR_USER_NOT_FOUND, HttpStatus.BAD_REQUEST);
             }
 
             // get instance of the user
@@ -1219,7 +1219,7 @@ public class CalendarEngine {
         } catch (UserCalendarNotFoundException e) {
             // e.g. when the user doesn't have Exams Calendar
             logger.error(buildExceptionMessage(e));
-            return new DTOgenerateResponseToController(false, COLLEGE_CALENDAR_NOT_FOUND, HttpStatus.NOT_ACCEPTABLE);
+            return new DTOgenerateResponseToController(false, ERROR_COLLEGE_CALENDAR_NOT_FOUND, HttpStatus.NOT_ACCEPTABLE);
         } catch (TokenResponseException e) {
             logger.error(buildExceptionMessage(e));
             if (e.getStatusCode() == HttpStatus.BAD_REQUEST.value() && e.getDetails().getError().equals("invalid_grant")) {
@@ -1278,7 +1278,7 @@ public class CalendarEngine {
             Optional<User> maybeUser = userRepo.findUserBySubjectID(sub);
 
             if (maybeUser.isEmpty()) {
-                return new DTOstudyPlanResponseToController(false, ERROR_UNAUTHORIZED_USER, HttpStatus.UNAUTHORIZED);
+                return new DTOstudyPlanResponseToController(false, ERROR_USER_NOT_FOUND, HttpStatus.BAD_REQUEST);
             }
             return new DTOstudyPlanResponseToController(true, NO_PROBLEM, HttpStatus.OK, maybeUser.get().getLatestStudyPlan());
         } catch (Exception e) {

--- a/src/main/java/com/example/planit/utill/Constants.java
+++ b/src/main/java/com/example/planit/utill/Constants.java
@@ -51,8 +51,8 @@ public class Constants {
     public static final String ERROR_ILLEGAL_CHARACTERS_IN_AUTH_CODE = "There are illegal characters in the auth code";
     public static final String ERROR_CALENDRIFIC_EXCEPTION = "Error From Callendrific";
     public static String ERROR_NO_VALID_ACCESS_TOKEN = "Access Token not valid anymore.";
-    public static String COURSE_ALREADY_EXIST = "Course already exists in database";
+    public static String ERROR_COURSE_ALREADY_EXIST = "Course already exists in database";
     public static String ERROR_COURSE_NOT_FOUND = "Course does not exist in database";
 
-    public static String COLLEGE_CALENDAR_NOT_FOUND = "College calendar does not found";
+    public static String ERROR_COLLEGE_CALENDAR_NOT_FOUND = "College calendar does not found";
 }


### PR DESCRIPTION
I've fixed the inconsistncy of responses messages.
The standard is the following:
For the case of a user that isn't registered, returns 400 BAD_REQUEST and ERROR_USER_NOT_FOUND. 
For the case of a user that isn't an admin, returns 401 UNAUTHORIZED and ERROR_UNAUTHORIZED_USER. 

Also, I've fixed all constants' names (of error kind) to begin with "ERROR" prefix.

Fix #18 