### PR TITLE
Regenerate study plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ build/
 
 ### VS Code ###
 .vscode/
+*.log

--- a/src/main/java/com/example/planit/controller/CalendarController.java
+++ b/src/main/java/com/example/planit/controller/CalendarController.java
@@ -55,9 +55,8 @@ public class CalendarController {
         logger.info(MessageFormat.format("User {0}: has requested POST /scan with params: sub={0}, start={1}, end={2}", sub, start, end));
 
         DTOscanResponseToController scanResponseToController = calendarEngine.generateNewStudyPlan(sub, start, end, decisions);
-        long t = System.currentTimeMillis();
-        long res = t - s;
-        logger.info(MessageFormat.format("User {0}: scan time is {1} ms", sub, res));
+
+        logger.info(MessageFormat.format("User {0}: scan time is {1} ms", sub, (System.currentTimeMillis() - s)));
 
         return ResponseEntity.status(scanResponseToController.getHttpStatus())
                 .body(new DTOscanResponseToClient(
@@ -73,11 +72,9 @@ public class CalendarController {
         long s = System.currentTimeMillis();
         logger.info(MessageFormat.format("User {0}: has requested POST /re-generate with params: sub={0}", sub));
 
-
         DTOscanResponseToController scanResponseToController = calendarEngine.regenerateStudyPlan(sub, decisions);
-        long t = System.currentTimeMillis();
-        long res = t - s;
-        logger.info(MessageFormat.format("User {0}: scan time is {1} ms", sub, res));
+
+        logger.info(MessageFormat.format("User {0}: scan time is {1} ms", sub, System.currentTimeMillis() - s));
 
         return ResponseEntity.status(scanResponseToController.getHttpStatus())
                 .body(new DTOscanResponseToClient(
@@ -89,14 +86,13 @@ public class CalendarController {
 
     @GetMapping(value = "/study-plan")
     public ResponseEntity<DTOstudyPlanAndSessionResponseToClient> getLatestStudyPlan(@RequestParam String sub) {
+
         long s = System.currentTimeMillis();
         logger.info(MessageFormat.format("User {0}: has requested POST /study-plan with params: sub={0}", sub));
 
         DTOstudyPlanAndSessionResponseToController dtOstudyPlanAndSessionResponseToController = calendarEngine.getUserLatestStudyPlanAndUpComingSession(sub);
 
-        long t = System.currentTimeMillis();
-        long res = t - s;
-        logger.info(MessageFormat.format("User {0}: study-plan time is {1} ms", sub, res));
+        logger.info(MessageFormat.format("User {0}: study-plan time is {1} ms", sub, System.currentTimeMillis() - s));
 
 
         return ResponseEntity.status(dtOstudyPlanAndSessionResponseToController.getHttpStatus())

--- a/src/main/java/com/example/planit/controller/CalendarController.java
+++ b/src/main/java/com/example/planit/controller/CalendarController.java
@@ -14,9 +14,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import static com.example.planit.utill.Constants.PLAN_IT_WEB_PRODUCTION_URI;
+
 import java.text.MessageFormat;
 import java.util.Map;
+
+import static com.example.planit.utill.Constants.PLAN_IT_WEB_PRODUCTION_URI;
 
 @CrossOrigin(origins = {"http://localhost:3000", PLAN_IT_WEB_PRODUCTION_URI})
 @RestController
@@ -52,7 +54,27 @@ public class CalendarController {
         long s = System.currentTimeMillis();
         logger.info(MessageFormat.format("User {0}: has requested POST /scan with params: sub={0}, start={1}, end={2}", sub, start, end));
 
-        DTOscanResponseToController scanResponseToController = calendarEngine.scanUserEvents(sub, start, end, decisions);
+        DTOscanResponseToController scanResponseToController = calendarEngine.generateNewStudyPlan(sub, start, end, decisions);
+        long t = System.currentTimeMillis();
+        long res = t - s;
+        logger.info(MessageFormat.format("User {0}: scan time is {1} ms", sub, res));
+
+        return ResponseEntity.status(scanResponseToController.getHttpStatus())
+                .body(new DTOscanResponseToClient(
+                        scanResponseToController.isSucceed(),
+                        scanResponseToController.getDetails(),
+                        scanResponseToController.getFullDayEvents(),
+                        scanResponseToController.getStudyPlan()));
+    }
+
+    @PostMapping(value = "/re-generate", consumes = {MediaType.APPLICATION_JSON_VALUE})
+    public ResponseEntity<DTOscanResponseToClient> regenerateStudyPlan(@RequestParam String sub, @RequestBody(required = false) Map<Long, Boolean> decisions) {
+
+        long s = System.currentTimeMillis();
+        logger.info(MessageFormat.format("User {0}: has requested POST /re-generate with params: sub={0}", sub));
+
+
+        DTOscanResponseToController scanResponseToController = calendarEngine.regenerateStudyPlan(sub, decisions);
         long t = System.currentTimeMillis();
         long res = t - s;
         logger.info(MessageFormat.format("User {0}: scan time is {1} ms", sub, res));

--- a/src/main/java/com/example/planit/engine/CalendarEngine.java
+++ b/src/main/java/com/example/planit/engine/CalendarEngine.java
@@ -1027,7 +1027,7 @@ public class CalendarEngine {
                 service.events().insert(planItCalendarID, event).execute();
 
             } catch (GoogleJsonResponseException e) {
-                logger.error(MessageFormat.format("planitcalender id:{0}, google message:{1}", planItCalendarID, e.getMessage()));
+                logger.error(MessageFormat.format("plan_it_calendar id:{0}, google message:{1}", planItCalendarID, e.getMessage()));
                 throw e;
             }
         }
@@ -1401,10 +1401,10 @@ public class CalendarEngine {
      */
     private static void addBreakTimeInEndOfEachUserEvent(List<Event> userEvents, int userBreakTime) {
 
-        for (Event currntUserEvent : userEvents) {
-            Instant oldEndOfUserEvent = Instant.ofEpochMilli(currntUserEvent.getEnd().getDateTime().getValue());
+        for (Event currentUserEvent : userEvents) {
+            Instant oldEndOfUserEvent = Instant.ofEpochMilli(currentUserEvent.getEnd().getDateTime().getValue());
             Instant newEndOfUserEvent = oldEndOfUserEvent.plus(Math.min(2 * userBreakTime, SPACE_LIMIT_BETWEEN_EVENTS), ChronoUnit.MINUTES);
-            currntUserEvent.setEnd(new EventDateTime()
+            currentUserEvent.setEnd(new EventDateTime()
                     .setDateTime(new DateTime(newEndOfUserEvent.toEpochMilli()))
                     .setTimeZone(ISRAEL_TIME_ZONE));
         }
@@ -1425,9 +1425,16 @@ public class CalendarEngine {
             DTOuserCalendarsInformation userCalendarsInformation = getUserCalendarsInformation(user, start, end);
             logger.debug("user " + subjectID + ": after getting calendar information. " + measureTimeInstant.until(Instant.now(), ChronoUnit.SECONDS) + "s");
 
-            DTOscanResponseToController dtOscanResponseToController = scanUserEvents(user, start, end, userCalendarsInformation, decisions);
+            DTOscanResponseToController dtOscanResponseToController = scanUserEvents(
+                    user,
+                    start,
+                    end,
+                    userCalendarsInformation,
+                    decisions);
 
-            if (dtOscanResponseToController.isSucceed()) {
+            boolean isScanSucceed = dtOscanResponseToController.isSucceed();
+
+            if (isScanSucceed) {
                 user.setLatestStudyPlan(dtOscanResponseToController.getStudyPlan());
                 userRepo.save(user);
             }
@@ -1492,9 +1499,6 @@ public class CalendarEngine {
             if (isScanSucceed) {
                 String newStartDateOfStudyPlan = currentUser.getLatestStudyPlan().getStartDateTimeOfPlan();
                 dtOscanResponseToController.getStudyPlan().setStartDateTimeOfPlan(newStartDateOfStudyPlan);
-
-//                dtOscanResponseToController.getStudyPlan().setEndDateTimeOfPlan(
-//                        currentUser.getLatestStudyPlan().getEndDateTimeOfPlan());
 
                 dtOscanResponseToController.getStudyPlan().setTotalNumberOfStudySessions(
                         numberOfOldEvent + dtOscanResponseToController.getStudyPlan().getTotalNumberOfStudySessions());

--- a/src/main/java/com/example/planit/engine/CalendarEngine.java
+++ b/src/main/java/com/example/planit/engine/CalendarEngine.java
@@ -1102,7 +1102,7 @@ public class CalendarEngine {
      * @param end   the user's preferred end time to generate to (in ISO format)
      * @return a {@link DTOscanResponseToController} represents the information that should be returned to the scan controller
      */
-    public DTOscanResponseToController scanUserEvents(User user, String start, String end, DTOuserCalendarsInformation userCalendarsInformation, Map<Exam, Double> exam2Proportions, Map<Long, Boolean> decisions) throws GeneralSecurityException, IOException {
+    public DTOscanResponseToController scanUserEventsAndGeneratePlan(User user, String start, String end, DTOuserCalendarsInformation userCalendarsInformation, Map<Exam, Double> exam2Proportions, Map<Long, Boolean> decisions) throws GeneralSecurityException, IOException {
 
         StudyPlan studyPlan = new StudyPlan();
         studyPlan.setStartDateTimeOfPlan(start);
@@ -1430,7 +1430,7 @@ public class CalendarEngine {
             Map<Exam, Double> exam2Proportions = getExamsProportions(userCalendarsInformation.getExamsFound());
 
 
-            DTOscanResponseToController dtOscanResponseToController = scanUserEvents(
+            DTOscanResponseToController dtOscanResponseToController = scanUserEventsAndGeneratePlan(
                     user,
                     start,
                     end,
@@ -1542,15 +1542,18 @@ public class CalendarEngine {
             Map<Exam, Double> updatedExam2Proportions = new HashMap<>();
 
             for (Exam currentExam : userCalendarsInformation.getExamsFound()) {
-                Exam examFromMapOfProportions = exam2Proportions.keySet().stream().filter(exam -> exam.getDateTime().equals(currentExam.getDateTime()) &&
-                        exam.getCourse().getCourseName().equals(currentExam.getCourse().getCourseName())).findFirst().get();
+                Optional<Exam> maybeExamFromMapOfProportions = exam2Proportions.keySet().stream().filter(exam -> exam.getDateTime().equals(currentExam.getDateTime()) &&
+                        exam.getCourse().getCourseName().equals(currentExam.getCourse().getCourseName())).findFirst();
 
-                Double theUpdatedProportion = exam2Proportions.get(examFromMapOfProportions);
-                updatedExam2Proportions.put(currentExam, theUpdatedProportion);
+                if (maybeExamFromMapOfProportions.isPresent()) {
+                    Double theUpdatedProportion = exam2Proportions.get(maybeExamFromMapOfProportions.get());
+                    updatedExam2Proportions.put(currentExam, theUpdatedProportion);
+                }
+                
             }
 
             // original scan()
-            DTOscanResponseToController dtOscanResponseToController = scanUserEvents(
+            DTOscanResponseToController dtOscanResponseToController = scanUserEventsAndGeneratePlan(
                     currentUser,
                     start,
                     end,

--- a/src/main/java/com/example/planit/engine/CalendarEngine.java
+++ b/src/main/java/com/example/planit/engine/CalendarEngine.java
@@ -1058,6 +1058,8 @@ public class CalendarEngine {
                 newSessionIndex++;
             } else if (newSession.getStart().getValue() > (oldEvent.getEnd().getDateTime().getValue())) {
                 // new event starts after old event ends, move to next old event
+                // and add old event to list of overlapping events
+                overlappingEvents.add(oldEvent);
                 oldEventIndex++;
             } else if (newSession.getStart().equals(oldEvent.getStart().getDateTime())
                     && newSession.getEnd().equals(oldEvent.getEnd().getDateTime())
@@ -1076,6 +1078,14 @@ public class CalendarEngine {
             }
 
         }
+
+        // remove plan-it events that are after the last session
+        while (oldEventIndex < planItCalendarOldEvents.size()) {
+            Event oldEvent = planItCalendarOldEvents.get(oldEventIndex);
+            overlappingEvents.add(oldEvent);
+            oldEventIndex++;
+        }
+
         // removes all the events that are duplicates from the sessions list
         for (int i = newSessionsIndicesToBeRemoved.size() - 1; i >= 0; i--) {
             sessionsList.remove(newSessionsIndicesToBeRemoved.get(i).intValue());
@@ -1088,8 +1098,8 @@ public class CalendarEngine {
      * performs a scan on the user events and gather some information.
      * if no full day events found, performs generate PlanIt calendar
      *
-     * @param start     the user's preferred start time to generate from (in ISO format)
-     * @param end       the user's preferred end time to generate to (in ISO format)
+     * @param start the user's preferred start time to generate from (in ISO format)
+     * @param end   the user's preferred end time to generate to (in ISO format)
      * @return a {@link DTOscanResponseToController} represents the information that should be returned to the scan controller
      */
     public DTOscanResponseToController scanUserEvents(User user, String start, String end, DTOuserCalendarsInformation userCalendarsInformation, Map<Long, Boolean> decisions) throws GeneralSecurityException, IOException {

--- a/src/main/java/com/example/planit/engine/CalendarEngine.java
+++ b/src/main/java/com/example/planit/engine/CalendarEngine.java
@@ -1099,8 +1099,8 @@ public class CalendarEngine {
         studyPlan.setStartDateTimeOfPlan(start);
         studyPlan.setEndDateTimeOfPlan(end);
 
-            // fullDayEvents - a list of events that represents the user's full day events
-            List<Event> fullDayEvents = userCalendarsInformation.getFullDayEvents();
+        // fullDayEvents - a list of events that represents the user's full day events
+        List<Event> fullDayEvents = userCalendarsInformation.getFullDayEvents();
 
         // events - a list of events that represents all the user's events
         // planItCalendarOldEvents - a list of PlanIt calendar old events
@@ -1115,18 +1115,18 @@ public class CalendarEngine {
             return new DTOscanResponseToController(false, Constants.ERROR_NO_EXAMS_FOUND, HttpStatus.CONFLICT, fullDayEvents);
         }
 
-            // remove duplications
-            fullDayEvents = removeDuplicationsByDate(fullDayEvents);
+        // remove duplications
+        fullDayEvents = removeDuplicationsByDate(fullDayEvents);
 
-            // add the holidays
-            fullDayEvents = addHolidaysToFullDayEvents(fullDayEvents, start, end);
+        // add the holidays
+        fullDayEvents = addHolidaysToFullDayEvents(fullDayEvents, start, end);
 
-            // after we delete all the event we can. we send the rest of the fullDayEvents we don`t know how to handle.
-            if (fullDayEvents.size() != 0 && decisions.size() == 0) {
+        // after we delete all the event we can. we send the rest of the fullDayEvents we don`t know how to handle.
+        if (fullDayEvents.size() != 0 && decisions.size() == 0) {
 
-                // return the user with the updated list of fullDayEvents.
-                return new DTOscanResponseToController(false, Constants.UNHANDLED_FULL_DAY_EVENTS, HttpStatus.OK, fullDayEvents, new StudyPlan());
-            }
+            // return the user with the updated list of fullDayEvents.
+            return new DTOscanResponseToController(false, Constants.UNHANDLED_FULL_DAY_EVENTS, HttpStatus.OK, fullDayEvents, new StudyPlan());
+        }
 
         convertFullDayEventsToRegularGoogleEventsAccordingToDecisions(decisions, fullDayEvents, regularEvents);
 

--- a/src/main/java/com/example/planit/utill/Constants.java
+++ b/src/main/java/com/example/planit/utill/Constants.java
@@ -63,4 +63,7 @@ public class Constants {
     public static String ERROR_COLLEGE_CALENDAR_NOT_FOUND = "College calendar does not found";
 
     public static String ERROR_PLANIT_CALENDAR_NOT_FOUND = "PlanIT calendar does not found";
+
+    public static String ERROR_GENERATE_DAYS_NOT_VALID = "The generate days are no longer valid";
+    public static String ERROR_GENERATE_NOT_PERFORMED = "generate wasn't performed";
 }

--- a/src/main/java/com/example/planit/utill/exception/GeneralErrorInEngineException.java
+++ b/src/main/java/com/example/planit/utill/exception/GeneralErrorInEngineException.java
@@ -1,0 +1,57 @@
+package com.example.planit.utill.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class GeneralErrorInEngineException extends Exception {
+
+    private final boolean isSucceed;
+    private final String details;
+    private final HttpStatus httpStatus;
+
+    public GeneralErrorInEngineException(boolean isSucceed, String details, HttpStatus httpStatus) {
+        super();
+        this.isSucceed = isSucceed;
+        this.details = details;
+        this.httpStatus = httpStatus;
+    }
+
+    public GeneralErrorInEngineException(String message, boolean isSucceed, String details, HttpStatus httpStatus) {
+        super(message);
+        this.isSucceed = isSucceed;
+        this.details = details;
+        this.httpStatus = httpStatus;
+    }
+
+    public GeneralErrorInEngineException(String message, Throwable cause, boolean isSucceed, String details, HttpStatus httpStatus) {
+        super(message, cause);
+        this.isSucceed = isSucceed;
+        this.details = details;
+        this.httpStatus = httpStatus;
+    }
+
+    public GeneralErrorInEngineException(Throwable cause, boolean isSucceed, String details, HttpStatus httpStatus) {
+        super(cause);
+        this.isSucceed = isSucceed;
+        this.details = details;
+        this.httpStatus = httpStatus;
+    }
+
+    public GeneralErrorInEngineException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace, boolean isSucceed, String details, HttpStatus httpStatus) {
+        super(message, cause, enableSuppression, writableStackTrace);
+        this.isSucceed = isSucceed;
+        this.details = details;
+        this.httpStatus = httpStatus;
+    }
+
+    public boolean isSucceed() {
+        return isSucceed;
+    }
+
+    public String getDetails() {
+        return details;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/test/java/com/example/planit/engine/calendar/PlanITApplicationTests.java
+++ b/src/test/java/com/example/planit/engine/calendar/PlanITApplicationTests.java
@@ -26,7 +26,7 @@ class PlanITApplicationTests {
     @Test
     void noExams() {
         String expectedOutput = Constants.ERROR_NO_EXAMS_FOUND;
-        String actualOutput = calendarEngine.scanUserEvents(
+        String actualOutput = calendarEngine.generateNewStudyPlan(
                 subjectIDForTestInput,
                 "2022-12-31T22:00:00.000Z",
                 "2023-01-01T21:59:59.000Z",
@@ -37,7 +37,7 @@ class PlanITApplicationTests {
     @Test
     void OneExam() {
         String expectedOutput = Constants.NO_PROBLEM;
-        String actualOutput = calendarEngine.scanUserEvents(
+        String actualOutput = calendarEngine.generateNewStudyPlan(
                 subjectIDForTestInput,
                 "2023-01-04T22:00:00.000Z",
                 "2023-01-15T21:59:59.000Z",
@@ -48,7 +48,7 @@ class PlanITApplicationTests {
     @Test
     void moreThenOneExam() {
         String expectedOutput = Constants.NO_PROBLEM;
-        String actualOutput = calendarEngine.scanUserEvents(
+        String actualOutput = calendarEngine.generateNewStudyPlan(
                 subjectIDForTestInput,
                 "2023-01-15T22:00:00.000Z",
                 "2023-01-31T21:59:59.000Z",
@@ -59,7 +59,7 @@ class PlanITApplicationTests {
     @Test
     void unrecognizedCourseName() {
         String expectedOutput = Constants.ERROR_NO_EXAMS_FOUND;
-        String actualOutput = calendarEngine.scanUserEvents(
+        String actualOutput = calendarEngine.generateNewStudyPlan(
                 subjectIDForTestInput,
                 "2023-02-01T22:00:00.000Z",
                 "2023-02-15T21:59:59.000Z",
@@ -70,7 +70,7 @@ class PlanITApplicationTests {
     @Test
     void courseNameInHebrew() {
         String expectedOutput = Constants.NO_PROBLEM;
-        String actualOutput = calendarEngine.scanUserEvents(
+        String actualOutput = calendarEngine.generateNewStudyPlan(
                 subjectIDForTestInput,
                 "2023-02-16T22:00:00.000Z",
                 "2023-02-27T21:59:59.000Z",
@@ -81,7 +81,7 @@ class PlanITApplicationTests {
     @Test
     void courseNameInEnglish() {
         String expectedOutput = Constants.NO_PROBLEM;
-        String actualOutput = calendarEngine.scanUserEvents(
+        String actualOutput = calendarEngine.generateNewStudyPlan(
                 subjectIDForTestInput,
                 "2023-02-26T22:00:00.000Z",
                 "2023-03-05T21:59:59.000Z",
@@ -92,7 +92,7 @@ class PlanITApplicationTests {
     @Test
     void oneExamWithFullDayEvents() {
         String expectedOutput = Constants.UNHANDLED_FULL_DAY_EVENTS;
-        String actualOutput = calendarEngine.scanUserEvents(
+        String actualOutput = calendarEngine.generateNewStudyPlan(
                 subjectIDForTestInput,
                 "2023-03-16T22:00:00.000Z",
                 "2023-03-29T21:59:59.000Z",
@@ -103,7 +103,7 @@ class PlanITApplicationTests {
     @Test
     void threeExamsWithTwoWeeks() {
         String expectedOutput = Constants.UNHANDLED_FULL_DAY_EVENTS;
-        String actualOutput = calendarEngine.scanUserEvents(
+        String actualOutput = calendarEngine.generateNewStudyPlan(
                 subjectIDForTestInput,
                 "2023-05-01T22:00:00.000Z",
                 "2023-05-15T21:59:59.000Z",
@@ -114,7 +114,7 @@ class PlanITApplicationTests {
     @Test
     void twoExamsWithFourWeeks() {
         String expectedOutput = Constants.UNHANDLED_FULL_DAY_EVENTS;
-        String actualOutput = calendarEngine.scanUserEvents(
+        String actualOutput = calendarEngine.generateNewStudyPlan(
                 subjectIDForTestInput,
                 "2023-05-16T22:00:00.000Z",
                 "2023-06-15T21:59:59.000Z",
@@ -125,7 +125,7 @@ class PlanITApplicationTests {
     @Test
     void userNotFound() {
         String expectedOutput = Constants.ERROR_USER_NOT_FOUND;
-        String actualOutput = calendarEngine.scanUserEvents(
+        String actualOutput = calendarEngine.generateNewStudyPlan(
                 "1",
                 "2022-12-31T22:00:00.000Z",
                 "2023-01-31T21:59:59.000Z",
@@ -136,7 +136,7 @@ class PlanITApplicationTests {
     @Test
     void holidaysFoundInCalendar() {
         String expectedOutput = Constants.UNHANDLED_FULL_DAY_EVENTS;
-        DTOscanResponseToController scanResponse = calendarEngine.scanUserEvents(
+        DTOscanResponseToController scanResponse = calendarEngine.generateNewStudyPlan(
                 subjectIDForTestInput,
                 "2023-05-07T22:00:00.000Z",
                 "2023-05-28T21:59:59.000Z",
@@ -150,7 +150,7 @@ class PlanITApplicationTests {
     void scanWithDecisions() {
         decisions.put(1686009600000L, true);
         String expectedOutput = Constants.NO_PROBLEM;
-        DTOscanResponseToController scanResponse = calendarEngine.scanUserEvents(
+        DTOscanResponseToController scanResponse = calendarEngine.generateNewStudyPlan(
                 subjectIDForTestInput,
                 "2023-06-01T22:00:00.000Z",
                 "2023-06-09T21:59:59.000Z",

--- a/src/test/java/com/example/planit/engine/calendar/PlanITApplicationTests.java
+++ b/src/test/java/com/example/planit/engine/calendar/PlanITApplicationTests.java
@@ -143,7 +143,6 @@ class PlanITApplicationTests {
                 decisions);
         String actualOutput = scanResponse.getDetails();
         Assertions.assertEquals(expectedOutput, actualOutput);
-        Assertions.assertEquals(actualOutput, expectedOutput);
     }
 
     @Test
@@ -157,6 +156,5 @@ class PlanITApplicationTests {
                 decisions);
         String actualOutput = scanResponse.getDetails();
         Assertions.assertEquals(expectedOutput, actualOutput);
-        Assertions.assertEquals(actualOutput, expectedOutput);
     }
 }

--- a/src/test/java/com/example/planit/engine/calendar/PlanITApplicationTests.java
+++ b/src/test/java/com/example/planit/engine/calendar/PlanITApplicationTests.java
@@ -10,6 +10,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -156,5 +158,25 @@ class PlanITApplicationTests {
                 decisions);
         String actualOutput = scanResponse.getDetails();
         Assertions.assertEquals(expectedOutput, actualOutput);
+    }
+
+    @Test
+    void RegeneratePlan() {
+        String expectedOutput = Constants.NO_PROBLEM;
+        DTOscanResponseToController scanResponse = calendarEngine.generateNewStudyPlan(
+                subjectIDForTestInput,
+                "2023-08-30T22:00:00.000Z",
+                "2023-09-09T21:59:59.000Z",
+                decisions);
+
+        if (scanResponse.isSucceed()) {
+            DTOscanResponseToController regeneratePlanResponse = calendarEngine.regenerateStudyPlan(
+                    subjectIDForTestInput,
+                    decisions,
+                    Instant.parse("2023-09-01T22:00:00.000Z").plus(2, ChronoUnit.DAYS));
+
+            String actualOutput = regeneratePlanResponse.getDetails();
+            Assertions.assertEquals(expectedOutput, actualOutput);
+        }
     }
 }

--- a/src/test/java/com/example/planit/engine/calendar/regenerate/RegenerateStudyPlanTests.java
+++ b/src/test/java/com/example/planit/engine/calendar/regenerate/RegenerateStudyPlanTests.java
@@ -1,4 +1,4 @@
-package com.example.planit.engine.calendar;
+package com.example.planit.engine.calendar.regenerate;
 
 import com.example.planit.engine.CalendarEngine;
 import com.example.planit.utill.Constants;
@@ -10,13 +10,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
-class PlanITApplicationTests {
+public class RegenerateStudyPlanTests {
+
     @Autowired
     private CalendarEngine calendarEngine;
 
@@ -158,32 +158,4 @@ class PlanITApplicationTests {
         String actualOutput = scanResponse.getDetails();
         Assertions.assertEquals(expectedOutput, actualOutput);
     }
-
-    @Test
-    void RegeneratePlan() {
-        String expectedOutput = Constants.NO_PROBLEM;
-        decisions.put(1690329600000L, true);
-        decisions.put(1690416000000L, true);
-        decisions.put(1690329600000L, true);
-        DTOscanResponseToController scanResponse = calendarEngine.generateNewStudyPlan(
-                subjectIDForTestInput,
-//                "2023-08-30T22:00:00.000Z",
-//                "2023-09-09T21:59:59.000Z",
-                "2023-07-23T10:00:00.000Z",
-                "2023-08-04T21:59:59.000Z",
-                decisions);
-
-        if (scanResponse.isSucceed()) {
-            DTOscanResponseToController regeneratePlanResponse = calendarEngine.regenerateStudyPlan(
-                    subjectIDForTestInput,
-                    decisions,
-                    Instant.parse("2023-07-31T22:00:00.000Z")/*.plus(2, ChronoUnit.DAYS)*/);
-
-            String actualOutput = regeneratePlanResponse.getDetails();
-            Assertions.assertEquals(expectedOutput, actualOutput);
-        }
-    }
 }
-// 1690329600000
-// 1690416000000
-// 1690329600000


### PR DESCRIPTION
This PR implements the "regenerate" feature.

- Refactor the `scanUserEvents` method to be able to use it both in `/scan` (regular generate) and `/re-generate` (regenerate).
- Added two "wrapper" methods, one for each endpoint, in order to make different logic for each of the features.
- Added `GeneralErrorInEngineException` which can be used for delivering information as in `ResponseToController`, from methods where the rerturn value is different.
- Fixed existing tests to work properly after the refactor was made.
- Added a new test for the regenerate feature.
- Rename `scanUserEvents` to `scanUserEventsAndGeneratePlan`
- close #34 
- close #62 
- close #57 