### PR TITLE
Fix duplicate fullDayEvent

### DIFF
--- a/src/main/java/com/example/planit/engine/CalendarEngine.java
+++ b/src/main/java/com/example/planit/engine/CalendarEngine.java
@@ -1138,11 +1138,11 @@ public class CalendarEngine {
                 return new DTOscanResponseToController(false, Constants.ERROR_NO_EXAMS_FOUND, HttpStatus.CONFLICT, fullDayEvents);
             }
 
-            // remove duplications
-            fullDayEvents = removeDuplicationsByDate(fullDayEvents);
-
             // add the holidays
             fullDayEvents = addHolidaysToFullDayEvents(fullDayEvents, start, end);
+
+            // remove duplications
+            fullDayEvents = removeDuplicationsByDate(fullDayEvents);
 
             // after we delete all the event we can. we send the rest of the fullDayEvents we don`t know how to handle.
             if (fullDayEvents.size() != 0 && decisions.size() == 0) {
@@ -1298,6 +1298,8 @@ public class CalendarEngine {
             currentFullDayEventIndex++;
         }
 
+        fullDayEventsWithHolidays.sort(new EventComparator());
+
         return fullDayEventsWithHolidays;
     }
 
@@ -1318,10 +1320,11 @@ public class CalendarEngine {
             if (lastEventInModifiedList == null || lastEventInModifiedList.getStart().getDate().getValue() != fullDayEvent.getStart().getDate().getValue()) {
                 lastEventInModifiedList = fullDayEvent;
                 modifiedFullDayEventsList.add(lastEventInModifiedList);
-            } else {
+                // case for 2 full-day-events that don't have same summery-name
+            } else if (!lastEventInModifiedList.getSummary().equals(fullDayEvent.getSummary())) {
                 lastEventInModifiedList.setSummary(lastEventInModifiedList.getSummary() + " | " + fullDayEvent.getSummary());
             }
-
+            // else case will be ignored since we don't want to display the same dull-day-event twice
         }
 
         return modifiedFullDayEventsList;

--- a/src/main/java/com/example/planit/utill/EventComparator.java
+++ b/src/main/java/com/example/planit/utill/EventComparator.java
@@ -8,19 +8,24 @@ public class EventComparator implements Comparator<Event> {
 
     @Override
     public int compare(Event o1, Event o2) {
-        // case of o1 && o2 are full day events
-        if (o1.getStart().getDate() != null && o2.getStart().getDate() != null) {
-            return (int) ((o1.getStart().getDate().getValue()) - (o2.getStart().getDate().getValue()));
+        boolean o1IsFullDayEvent = o1.getStart().getDate() != null;
+        boolean o2IsFullDayEvent = o2.getStart().getDate() != null;
+
+        // Case when both are full day events
+        if (o1IsFullDayEvent && o2IsFullDayEvent) {
+            return Long.compare(o1.getStart().getDate().getValue(), o2.getStart().getDate().getValue());
         }
-        // case of o1 is a full day events
-        if (o1.getStart().getDate() != null) {
-            return (int) ((o1.getStart().getDate().getValue()) - (o2.getStart().getDateTime().getValue()));
+        // Case when o1 is a full day event
+        else if (o1IsFullDayEvent) {
+            return Long.compare(o1.getStart().getDate().getValue(), o2.getStart().getDateTime().getValue());
         }
-        // case of o2 is a full day events
-        if (o2.getStart().getDate() != null) {
-            return (int) ((o1.getStart().getDateTime().getValue()) - (o2.getStart().getDate().getValue()));
+        // Case when o2 is a full day event
+        else if (o2IsFullDayEvent) {
+            return Long.compare(o1.getStart().getDateTime().getValue(), o2.getStart().getDate().getValue());
         }
-        // case of regular events
-        return (int) ((o1.getStart().getDateTime().getValue()) - (o2.getStart().getDateTime().getValue()));
+        // Case when both are regular events
+        else {
+            return Long.compare(o1.getStart().getDateTime().getValue(), o2.getStart().getDateTime().getValue());
+        }
     }
 }

--- a/src/test/java/com/example/planit/engine/calendar/event/EventComparatorTest.java
+++ b/src/test/java/com/example/planit/engine/calendar/event/EventComparatorTest.java
@@ -1,0 +1,90 @@
+package com.example.planit.engine.calendar.event;
+
+import com.google.api.client.util.DateTime;
+import com.google.api.services.calendar.model.Event;
+import com.google.api.services.calendar.model.EventDateTime;
+import org.junit.jupiter.api.Test;
+import com.example.planit.utill.EventComparator;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EventComparatorTest {
+
+    @Test
+    public void testEventComparator() {
+        EventComparator comparator = new EventComparator();
+        // Create some sample events for testing
+        long dateTime1 = 1690804800000L;
+        long dateTime2 = 1690884000000L;
+        long dateTime3 = 1690963200000L;
+        long fullDayDate1 = 1691804800000L;
+        long fullDayDate2 = 1692804800000L;
+
+        Event event1 = new Event().setStart(new EventDateTime().setDateTime(new DateTime(dateTime1)));
+        Event event2 = new Event().setStart(new EventDateTime().setDateTime(new DateTime(dateTime2)));
+        Event event3 = new Event().setStart(new EventDateTime().setDateTime(new DateTime(dateTime3)));
+        Event eventFullDay1 = new Event().setStart(new EventDateTime().setDate(new DateTime(fullDayDate1)));
+        Event eventFullDay2 = new Event().setStart(new EventDateTime().setDate(new DateTime(fullDayDate2)));
+
+        List<Event> events = new ArrayList<>();
+        events.add(event2);
+        events.add(event3);
+        events.add(event1);
+        events.add(eventFullDay1);
+        events.add(eventFullDay2);
+
+        // Shuffle the list to ensure the comparator handles unordered events correctly
+        Collections.shuffle(events);
+
+        // Sort the events using the comparator
+        events.sort(comparator);
+
+        // The sorted order should be: event1, event2, event3, eventFullDay1, eventFullDay2
+        assertEquals(event1, events.get(0));
+        assertEquals(event2, events.get(1));
+        assertEquals(event3, events.get(2));
+        assertEquals(eventFullDay1, events.get(3));
+        assertEquals(eventFullDay2, events.get(4));
+    }
+
+    @Test
+    public void testEventComparator2() {
+        EventComparator comparator = new EventComparator();
+
+        // Create some sample events for testing
+        long fullDayDate1 = 1687359469000L;
+        long fullDayDate2 = 1688601600000L;
+        long fullDayDate3 = 1690329600000L;
+        long fullDayDate4 = 1690329600000L;
+        long fullDayDate5 = 1690416000000L;
+
+        Event eventFullDay1 = new Event().setStart(new EventDateTime().setDate(new DateTime(fullDayDate1)));
+        Event eventFullDay2 = new Event().setStart(new EventDateTime().setDate(new DateTime(fullDayDate2)));
+        Event eventFullDay3 = new Event().setStart(new EventDateTime().setDate(new DateTime(fullDayDate3)));
+        Event eventFullDay4 = new Event().setStart(new EventDateTime().setDate(new DateTime(fullDayDate4)));
+        Event eventFullDay5 = new Event().setStart(new EventDateTime().setDate(new DateTime(fullDayDate5)));
+
+        List<Event> events = new ArrayList<>();
+        events.add(eventFullDay3);
+        events.add(eventFullDay4);
+        events.add(eventFullDay5);
+        events.add(eventFullDay1);
+        events.add(eventFullDay2);
+
+        // Shuffle the list to ensure the comparator handles unordered events correctly
+        Collections.shuffle(events);
+
+        // Sort the events using the comparator
+        events.sort(comparator);
+
+        // The sorted order should be: event1, event2, event3, eventFullDay1, eventFullDay2
+        assertEquals(eventFullDay1, events.get(0));
+        assertEquals(eventFullDay2, events.get(1));
+        assertEquals(eventFullDay3, events.get(2));
+        assertEquals(eventFullDay4, events.get(3));
+        assertEquals(eventFullDay5, events.get(4));
+    }
+}


### PR DESCRIPTION
Fixed bug of duplicate full day events Refer to #59
problem was that after Add full-day-events from DB the full day events list wasnt sorted, i applied a sort + rewrote the EventComparator to be more readable

close #59

if you are still afraid to merge this PR, please tell me and i will add more tests to prove the comparator is not broken. 