### PR TITLE
Fix break time in the start of each user event

### DIFF
--- a/src/main/java/com/example/planit/utill/Constants.java
+++ b/src/main/java/com/example/planit/utill/Constants.java
@@ -10,9 +10,9 @@ public class Constants {
 
     public static final long MINUTES_TO_MILLIS = 60000;
 
-    public static final int HOUR_IN_MINUTES = 60;
+    public static final int MINUTE_AS_SECONDS = 60;
 
-    public static final int SPACE_LIMIT_BETWEEN_EVENTS = 60;
+    public static final int SPACE_LIMIT_BETWEEN_EVENTS_IN_MINUTES = 60;
 
     /**
      * Application name.

--- a/src/test/java/com/example/planit/engine/calendar/PlanITApplicationTests.java
+++ b/src/test/java/com/example/planit/engine/calendar/PlanITApplicationTests.java
@@ -160,7 +160,7 @@ class PlanITApplicationTests {
     }
 
     @Test
-    void RegeneratePlan() {
+    void RegeneratePlanWithFullDaysEvent() {
         String expectedOutput = Constants.NO_PROBLEM;
         decisions.put(1690329600000L, true);
         decisions.put(1690416000000L, true);
@@ -178,6 +178,26 @@ class PlanITApplicationTests {
                     subjectIDForTestInput,
                     decisions,
                     Instant.parse("2023-07-31T22:00:00.000Z")/*.plus(2, ChronoUnit.DAYS)*/);
+
+            String actualOutput = regeneratePlanResponse.getDetails();
+            Assertions.assertEquals(expectedOutput, actualOutput);
+        }
+    }
+
+    @Test
+    void RegeneratePlanWithoutFullDaysEvent() {
+        String expectedOutput = Constants.NO_PROBLEM;
+        DTOscanResponseToController scanResponse = calendarEngine.generateNewStudyPlan(
+                subjectIDForTestInput,
+                "2023-08-06T00:00:00.000Z",
+                "2023-08-12T21:59:59.000Z",
+                decisions);
+
+        if (scanResponse.isSucceed()) {
+            DTOscanResponseToController regeneratePlanResponse = calendarEngine.regenerateStudyPlan(
+                    subjectIDForTestInput,
+                    decisions,
+                    Instant.parse("2023-08-07T22:00:00.000Z"));
 
             String actualOutput = regeneratePlanResponse.getDetails();
             Assertions.assertEquals(expectedOutput, actualOutput);


### PR DESCRIPTION
1.I add new function addBreakTimeInStartOfEachUserEvent.
it adds break time in start of each user event.
it is same as the function addBreakTimeInEndOfEachUserEvent.

as you can see in the picture, the event in the 7(mon) amd the event in the 8(tue) show the fix of the issue we have in #65 

close #65 


![image](https://github.com/itayf9/Plan_It_Enigne/assets/102179412/0bb398d4-81e3-41cf-bdc0-cb7b82a4ce90)

