### PR TITLE
Change type of "upcoming study session"

### DIFF
--- a/src/main/java/com/example/planit/model/event/EventClientRepresentation.java
+++ b/src/main/java/com/example/planit/model/event/EventClientRepresentation.java
@@ -1,0 +1,23 @@
+package com.example.planit.model.event;
+
+import com.example.planit.model.timeslot.TimeSlot;
+import com.google.api.client.util.DateTime;
+
+public class EventClientRepresentation extends TimeSlot {
+    private final String courseName;
+    private final String description;
+
+    public EventClientRepresentation(DateTime start, DateTime end, String courseName, String description) {
+        super(start, end);
+        this.courseName = courseName;
+        this.description = description;
+    }
+
+    public String getCourseName() {
+        return courseName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/example/planit/model/event/EventComparator.java
+++ b/src/main/java/com/example/planit/model/event/EventComparator.java
@@ -1,4 +1,4 @@
-package com.example.planit.utill;
+package com.example.planit.model.event;
 
 import com.google.api.services.calendar.model.Event;
 

--- a/src/main/java/com/example/planit/model/studysession/StudySession.java
+++ b/src/main/java/com/example/planit/model/studysession/StudySession.java
@@ -17,13 +17,6 @@ public class StudySession extends TimeSlot {
         this.examToStudyFor = null;
     }
 
-    public StudySession(DateTime start, DateTime end, String courseName, String description) {
-        super(start, end);
-        this.courseName = courseName;
-        this.description = description;
-        this.examToStudyFor = null;
-    }
-
     public String getCourseName() {
         return courseName;
     }

--- a/src/main/java/com/example/planit/utill/Utility.java
+++ b/src/main/java/com/example/planit/utill/Utility.java
@@ -1,6 +1,6 @@
 package com.example.planit.utill;
 
-import com.example.planit.model.studysession.StudySession;
+import com.example.planit.model.event.EventClientRepresentation;
 import com.example.planit.utill.dto.DTOstartAndEndOfInterval;
 import com.google.api.client.util.DateTime;
 import com.google.api.services.calendar.model.Event;
@@ -230,9 +230,9 @@ public class Utility {
      * @param event event that convert to study session
      * @return study session after extract the information from the event
      */
-    public static StudySession convertEventToUpcomingStudySession(Event event) {
+    public static EventClientRepresentation convertEventToUpcomingStudySession(Event event) {
 
-        return new StudySession(event.getStart().getDateTime(),
+        return new EventClientRepresentation(event.getStart().getDateTime(),
                 event.getEnd().getDateTime(),
                 event.getSummary(),
                 event.getDescription());

--- a/src/main/java/com/example/planit/utill/dto/DTOscanResponseToClient.java
+++ b/src/main/java/com/example/planit/utill/dto/DTOscanResponseToClient.java
@@ -1,7 +1,7 @@
 package com.example.planit.utill.dto;
 
+import com.example.planit.model.event.EventClientRepresentation;
 import com.example.planit.model.mongo.user.StudyPlan;
-import com.example.planit.model.studysession.StudySession;
 import com.google.api.services.calendar.model.Event;
 
 import java.util.List;
@@ -10,10 +10,10 @@ public class DTOscanResponseToClient extends DTOstatus {
     private final List<Event> fullDayEvents;
     private final StudyPlan studyPlan;
 
-    private final StudySession upComingSession;
+    private final EventClientRepresentation upComingSession;
 
 
-    public DTOscanResponseToClient(boolean isSucceed, String details, List<Event> fullDayEvents, StudyPlan studyPlan, StudySession upComingSession) {
+    public DTOscanResponseToClient(boolean isSucceed, String details, List<Event> fullDayEvents, StudyPlan studyPlan, EventClientRepresentation upComingSession) {
         super(isSucceed, details);
         this.fullDayEvents = fullDayEvents;
         this.studyPlan = studyPlan;
@@ -28,7 +28,7 @@ public class DTOscanResponseToClient extends DTOstatus {
         return fullDayEvents;
     }
 
-    public StudySession getUpComingSession() {
+    public EventClientRepresentation getUpComingSession() {
         return upComingSession;
     }
 }

--- a/src/main/java/com/example/planit/utill/dto/DTOscanResponseToController.java
+++ b/src/main/java/com/example/planit/utill/dto/DTOscanResponseToController.java
@@ -1,7 +1,7 @@
 package com.example.planit.utill.dto;
 
+import com.example.planit.model.event.EventClientRepresentation;
 import com.example.planit.model.mongo.user.StudyPlan;
-import com.example.planit.model.studysession.StudySession;
 import com.google.api.services.calendar.model.Event;
 import org.springframework.http.HttpStatus;
 
@@ -12,7 +12,7 @@ public class DTOscanResponseToController extends DTOresponseToController {
 
     private final StudyPlan studyPlan;
 
-    private final StudySession upComingSession;
+    private final EventClientRepresentation upComingSession;
 
 
     public DTOscanResponseToController(boolean isSucceed, String details, HttpStatus httpStatus) {
@@ -29,7 +29,7 @@ public class DTOscanResponseToController extends DTOresponseToController {
         this.upComingSession = null;
     }
 
-    public DTOscanResponseToController(boolean isSucceed, String details, HttpStatus httpStatus, StudyPlan studyPlan, StudySession upComingSession) {
+    public DTOscanResponseToController(boolean isSucceed, String details, HttpStatus httpStatus, StudyPlan studyPlan, EventClientRepresentation upComingSession) {
         super(isSucceed, details, httpStatus);
         this.fullDayEvents = null;
         this.studyPlan = studyPlan;
@@ -44,7 +44,7 @@ public class DTOscanResponseToController extends DTOresponseToController {
         return fullDayEvents;
     }
 
-    public StudySession getUpComingSession() {
+    public EventClientRepresentation getUpComingSession() {
         return upComingSession;
     }
 }

--- a/src/main/java/com/example/planit/utill/dto/DTOstudyPlanAndSessionResponseToClient.java
+++ b/src/main/java/com/example/planit/utill/dto/DTOstudyPlanAndSessionResponseToClient.java
@@ -1,25 +1,25 @@
 package com.example.planit.utill.dto;
 
+import com.example.planit.model.event.EventClientRepresentation;
 import com.example.planit.model.mongo.user.StudyPlan;
-import com.example.planit.model.studysession.StudySession;
 
 public class DTOstudyPlanAndSessionResponseToClient extends DTOstatus {
 
     private final StudyPlan studyPlan;
 
-    private final StudySession upComingSession;
+    private final EventClientRepresentation upComingSession;
 
-    public DTOstudyPlanAndSessionResponseToClient(boolean isSucceed, String details, StudyPlan studyPlan, StudySession ucomingSession) {
+    public DTOstudyPlanAndSessionResponseToClient(boolean isSucceed, String details, StudyPlan studyPlan, EventClientRepresentation upComingSession) {
         super(isSucceed, details);
         this.studyPlan = studyPlan;
-        this.upComingSession = ucomingSession;
+        this.upComingSession = upComingSession;
     }
 
     public StudyPlan getStudyPlan() {
         return studyPlan;
     }
 
-    public StudySession getUpComingSession() {
+    public EventClientRepresentation getUpComingSession() {
         return upComingSession;
     }
 }

--- a/src/main/java/com/example/planit/utill/dto/DTOstudyPlanAndSessionResponseToController.java
+++ b/src/main/java/com/example/planit/utill/dto/DTOstudyPlanAndSessionResponseToController.java
@@ -1,15 +1,15 @@
 package com.example.planit.utill.dto;
 
+import com.example.planit.model.event.EventClientRepresentation;
 import com.example.planit.model.mongo.user.StudyPlan;
-import com.example.planit.model.studysession.StudySession;
 import org.springframework.http.HttpStatus;
 
 public class DTOstudyPlanAndSessionResponseToController extends DTOresponseToController {
 
     private final StudyPlan studyPlan;
-    private final StudySession upComingSession;
+    private final EventClientRepresentation upComingSession;
 
-    public DTOstudyPlanAndSessionResponseToController(boolean isSucceed, String details, HttpStatus httpStatus, StudyPlan studyPlan, StudySession upcomingSession) {
+    public DTOstudyPlanAndSessionResponseToController(boolean isSucceed, String details, HttpStatus httpStatus, StudyPlan studyPlan, EventClientRepresentation upcomingSession) {
         super(isSucceed, details, httpStatus);
         this.studyPlan = studyPlan;
         this.upComingSession = upcomingSession;
@@ -25,7 +25,7 @@ public class DTOstudyPlanAndSessionResponseToController extends DTOresponseToCon
         return studyPlan;
     }
 
-    public StudySession getUpComingSession() {
+    public EventClientRepresentation getUpComingSession() {
         return upComingSession;
     }
 }

--- a/src/test/java/com/example/planit/engine/calendar/event/EventComparatorTest.java
+++ b/src/test/java/com/example/planit/engine/calendar/event/EventComparatorTest.java
@@ -1,10 +1,11 @@
 package com.example.planit.engine.calendar.event;
 
+import com.example.planit.model.event.EventComparator;
 import com.google.api.client.util.DateTime;
 import com.google.api.services.calendar.model.Event;
 import com.google.api.services.calendar.model.EventDateTime;
 import org.junit.jupiter.api.Test;
-import com.example.planit.utill.EventComparator;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION
I've changed the object type of the upcoming study session, in every relevant DTO,  from `StudySession` to `EventClientRepresentation`.

I've decided not to include the color id of the event in that object, since it looks better when the event color at the website is "PlanIT blue" and not a custom color which may not look good (green, purple..).

Closes #60 