### PR TITLE
Add the DELETE /study-plan endpoint

### DIFF
--- a/src/main/java/com/example/planit/controller/CalendarController.java
+++ b/src/main/java/com/example/planit/controller/CalendarController.java
@@ -3,10 +3,7 @@ package com.example.planit.controller;
 import com.example.planit.engine.CalendarEngine;
 import com.example.planit.holidays.PlanITHolidaysWrapper;
 import com.example.planit.model.mongo.holiday.HolidayRepository;
-import com.example.planit.utill.dto.DTOscanResponseToClient;
-import com.example.planit.utill.dto.DTOscanResponseToController;
-import com.example.planit.utill.dto.DTOstudyPlanAndSessionResponseToClient;
-import com.example.planit.utill.dto.DTOstudyPlanAndSessionResponseToController;
+import com.example.planit.utill.dto.*;
 import jakarta.annotation.PostConstruct;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -90,16 +87,33 @@ public class CalendarController {
         long s = System.currentTimeMillis();
         logger.info(MessageFormat.format("User {0}: has requested POST /study-plan with params: sub={0}", sub));
 
-        DTOstudyPlanAndSessionResponseToController dtOstudyPlanAndSessionResponseToController = calendarEngine.getUserLatestStudyPlanAndUpComingSession(sub);
+        DTOstudyPlanAndSessionResponseToController studyPlanAndSessionResponseToController = calendarEngine.getUserLatestStudyPlanAndUpComingSession(sub);
 
         logger.info(MessageFormat.format("User {0}: study-plan time is {1} ms", sub, System.currentTimeMillis() - s));
 
 
-        return ResponseEntity.status(dtOstudyPlanAndSessionResponseToController.getHttpStatus())
+        return ResponseEntity.status(studyPlanAndSessionResponseToController.getHttpStatus())
                 .body(new DTOstudyPlanAndSessionResponseToClient(
-                        dtOstudyPlanAndSessionResponseToController.isSucceed(),
-                        dtOstudyPlanAndSessionResponseToController.getDetails(),
-                        dtOstudyPlanAndSessionResponseToController.getStudyPlan(),
-                        dtOstudyPlanAndSessionResponseToController.getUpComingSession()));
+                        studyPlanAndSessionResponseToController.isSucceed(),
+                        studyPlanAndSessionResponseToController.getDetails(),
+                        studyPlanAndSessionResponseToController.getStudyPlan(),
+                        studyPlanAndSessionResponseToController.getUpComingSession()));
+    }
+
+    @DeleteMapping(value = "/study-plan")
+    public ResponseEntity<DTOstatus> removeLatestStudyPlan(@RequestParam String sub) {
+
+        long s = System.currentTimeMillis();
+        logger.info(MessageFormat.format("User {0}: has requested DELETE /study-plan with params: sub={0}", sub));
+
+        DTOresponseToController responseToController = calendarEngine.removeUserLatestStudyPlanAndUpComingSession(sub);
+
+        logger.info(MessageFormat.format("User {0}: remove study-plan time is {1} ms", sub, System.currentTimeMillis() - s));
+
+        return ResponseEntity.status(responseToController.getHttpStatus())
+                .body(new DTOstatus(
+                        responseToController.isSucceed(),
+                        responseToController.getDetails()
+                ));
     }
 }

--- a/src/main/java/com/example/planit/utill/Constants.java
+++ b/src/main/java/com/example/planit/utill/Constants.java
@@ -56,6 +56,7 @@ public class Constants {
     public static final String ERROR_DEFAULT = "Some Internal Server Error";
     public static final String ERROR_ILLEGAL_CHARACTERS_IN_AUTH_CODE = "There are illegal characters in the auth code";
     public static final String ERROR_CALENDRIFIC_EXCEPTION = "Error From Callendrific";
+    public static final String NO_STUDY_PLAN = "No study plan";
     public static String ERROR_NO_VALID_ACCESS_TOKEN = "Access Token not valid anymore.";
     public static String ERROR_COURSE_ALREADY_EXIST = "Course already exists in database";
     public static String ERROR_COURSE_NOT_FOUND = "Course does not exist in database";


### PR DESCRIPTION
Added a new endpoint of DELETE `/study-plan`.
It removes all the events on PlanIt Calendar between the `start` and the `end` of the user's latest study plan.
Returns a simple `DTOstatus`, indicating that the proccess was completed successfully.

Closes #72 